### PR TITLE
metainfo: Fix license case

### DIFF
--- a/org.gnome.Games.LibretroPlugin.PicoDrive.metainfo.xml
+++ b/org.gnome.Games.LibretroPlugin.PicoDrive.metainfo.xml
@@ -10,6 +10,6 @@
   <url type="homepage">https://github.com/libretro/picodrive</url>
   <url type="bugtracker">https://github.com/libretro/picodrive/issues</url>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-Proprietary=https://github.com/libretro/picodrive/blob/master/COPYING</project_license>
+  <project_license>LicenseRef-proprietary=https://github.com/libretro/picodrive/blob/master/COPYING</project_license>
   <update_contact>alexm_at_gnome.org</update_contact>
 </component>


### PR DESCRIPTION
Looks like "proprietary" should be lowercase, otherwise it confuses
gnome-software even though the file validates.